### PR TITLE
honoring `.store` and more `.store` vs. `.score`

### DIFF
--- a/spell.js
+++ b/spell.js
@@ -46,13 +46,15 @@ function spell_store(cb) {
   }
 }
 
-function spell_train(corpus,regex) {
+function spell_train(corpus,regex,opts) {
   var match, word;
   regex         = regex || /[a-z]+/g;
   corpus        = corpus.toLowerCase();
+  opts          = opts || {};
   while ((match = regex.exec(corpus))) {
     word        = match[0];
-    spell_add_word(word, 1);
+    opts.score = 1;
+    spell_add_word(word, opts);
   }
 }
 
@@ -157,9 +159,10 @@ function spell_load(corpus, opts) {
   if(opts.reset) { dict  = {}; }
   if('object' === typeof opts.corpus) {
     for(var key in opts.corpus) { 
-      spell_add_word(key, {score: opts.corpus[key]}); 
+      opts.score = opts.corpus[key];
+      spell_add_word(key, opts);
     }
-  } else { spell_train(opts.corpus); }
+  } else { spell_train(opts.corpus, null, opts); }
   if(opts.store) { spell_store(opts.after_store); }
 }
 
@@ -188,7 +191,7 @@ function spell_add_word(word, opts) {
   }
   opts        = 'object' === typeof opts ? opts : {};
   opts.score  = opts.score  || 1;
-  opts.store  = opts.store  || true;
+  opts.store  = (false !== opts.store);
   opts.done   = opts.done   || noop;
   word        = word.toLowerCase();
   dict[word]  = 

--- a/spell.js
+++ b/spell.js
@@ -151,7 +151,7 @@ function spell_load(corpus, opts) {
   if ('string' === typeof opts)   { opts = {corpus: opts }; }
   opts               = 'object' === typeof opts ? opts : {};
   opts.reset         = (opts.reset !== false);
-  opts.store         = (opts.score !== false);
+  opts.store         = (opts.store !== false);
   opts.after_store   = opts.after_store   || noop;
   opts.corpus        = opts.corpus        || '';
   if(opts.reset) { dict  = {}; }
@@ -215,7 +215,7 @@ function spell_add_word(word, opts) {
  */
 function spell_remove_word(word,opts) {
   opts        = 'object' === typeof opts ? opts : {};
-  opts.store  = (opts.score !== false);
+  opts.store  = (opts.store !== false);
   opts.done   = opts.done   || noop;
   if (dict.hasOwnProperty(word)) { delete dict[word]; }
   if(opts.store) { spell_store(opts.done); }


### PR DESCRIPTION
as is, even if you fix all the store vs. score typos it won't honor the param

the `opts` object needs to be passed to all subcalls or the original requests options are not honored. this includes store, where calling `load()` can make a write call as much as once per word 