### PR TITLE
Adding check method, to check a word without generating suggestions

### DIFF
--- a/spell.js
+++ b/spell.js
@@ -37,7 +37,7 @@
 var dict          = 
     dict_store && typeof dict_store.get === 'function' ? dict_store.get() : {}
   , noop          = function(){}
-  , alphabet      = "abcdefghijklmnopqrstuvwxyz".split("")
+  , alphabet      = "abcdefghijklmnopqrstuvwxyzáéíóúñäëïöüàèìòùâêîôûç".split("")
   ;
 
 function spell_store(cb) { 
@@ -48,7 +48,7 @@ function spell_store(cb) {
 
 function spell_train(corpus,regex) {
   var match, word;
-  regex         = regex || /[a-z]+/g;
+  regex         = regex || /[a-záéíóúñäëïöüàèìòùâêîôûç]+/g;
   corpus        = corpus.toLowerCase();
   while ((match = regex.exec(corpus))) {
     word        = match[0];

--- a/spell.js
+++ b/spell.js
@@ -310,6 +310,24 @@ function spell_export(word) {
   return {corpus: dict};
 }
 
+/*
+ * check
+ *
+ * returns true or false for a given word if exists in dictionary
+ *
+ * e.g.
+ * spell.check('speling');
+ *
+ * @param {word:string:required}
+ *        the word you want to spell check
+ *
+ * @return {boolean}
+ *                 false
+ */
+function spell_check(word) {
+  return dict.hasOwnProperty(word);
+}
+
 return { reset       : spell_reset
        , load        : spell_load
        , "export"    : spell_export
@@ -319,6 +337,7 @@ return { reset       : spell_reset
        , remove_word : spell_remove_word
        , removeWord  : spell_remove_word  // alias
        , suggest     : spell_suggest
+       , check       : spell_check
        , lucky       : spell_lucky
        };
   };


### PR DESCRIPTION
I had to check a large corpus word by word, with some very long words in Dutch language, generating suggestions for each was too resource intensive. With this new method I was able to mark the errors really fast and then obtain suggestions lazily upon user request.

``` javascript
var correct = dict.check(loopWord);
```
